### PR TITLE
feat: import from Jellyfin CSV + export collection, closes #16

### DIFF
--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 
     <!-- AndroidTV support -->
     <uses-feature android:name="android.software.leanback" android:required="false" />

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,20 @@ fn get_poster_cache_size(app: tauri::AppHandle) -> Result<i64, String> {
     Ok(total as i64)
 }
 
+/// Write a text file to the device Downloads directory.
+#[tauri::command]
+async fn write_to_downloads(
+    app: tauri::AppHandle,
+    filename: String,
+    content: String,
+) -> Result<(), String> {
+    let download_dir = app.path().download_dir().map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(&download_dir).map_err(|e| e.to_string())?;
+    let path = download_dir.join(&filename);
+    std::fs::write(&path, content.as_bytes()).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 /// Resize a picked image (already encoded as JPEG on the JS side) and
 /// persist it to the poster-cache directory.  The JS side does the canvas
 /// resize so all we receive here is the final JPEG bytes as base64.
@@ -222,6 +236,7 @@ pub fn run() {
             get_cached_poster,
             clear_poster_cache,
             get_poster_cache_size,
+            write_to_downloads,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/features/import/import.service.ts
+++ b/src/features/import/import.service.ts
@@ -1,0 +1,147 @@
+import {
+	checkMovieDuplicate,
+	checkTitleYearSimilar,
+	createMovie,
+} from "../movies/movies.service";
+import type { MovieFormat } from "../movies/movies.types";
+import {
+	fetchAndCachePoster,
+	searchMovieByTitleYear,
+} from "../tmdb/tmdb.service";
+import type { ImportRow, RawImportRow } from "./import.types";
+
+export function parseJellyfinCsv(text: string): RawImportRow[] {
+	const lines = text
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean);
+	// Skip header row
+	return lines
+		.slice(1)
+		.map((line) => {
+			const parts = line.split(",");
+			if (parts.length < 3) return null;
+			const resolution = parts[parts.length - 1].trim();
+			const yearStr = parts[parts.length - 2].trim();
+			const title = parts
+				.slice(0, parts.length - 2)
+				.join(",")
+				.trim();
+			const year = parseInt(yearStr, 10);
+			if (!title || Number.isNaN(year)) return null;
+			return { title, year, resolution };
+		})
+		.filter((r): r is RawImportRow => r !== null);
+}
+
+export function mapResolutionToFormat(resolution: string): MovieFormat {
+	const match = resolution.match(/(\d+)/);
+	const width = match ? parseInt(match[1], 10) : 0;
+	if (width >= 3840) return "4K";
+	if (width >= 1280) return "HD";
+	return "SD";
+}
+
+export async function processImportRows(
+	rows: RawImportRow[],
+	onProgress: (done: number, total: number) => void,
+): Promise<ImportRow[]> {
+	const results: ImportRow[] = [];
+
+	for (let i = 0; i < rows.length; i++) {
+		const raw = rows[i];
+		const format = mapResolutionToFormat(raw.resolution);
+		const matches = await searchMovieByTitleYear(raw.title, raw.year);
+
+		let status: ImportRow["status"];
+		let selectedMatch: ImportRow["selectedMatch"] = null;
+
+		if (matches.length === 0) {
+			const isDup = await checkTitleYearSimilar(raw.title, raw.year);
+			status = isDup ? "duplicate" : "not_found";
+		} else if (matches.length === 1) {
+			const isDup = await checkMovieDuplicate(matches[0].id);
+			status = isDup ? "duplicate" : "ready";
+			selectedMatch = matches[0];
+		} else {
+			// Multiple matches — check if the top result is already in collection
+			const isDup = await checkMovieDuplicate(matches[0].id);
+			if (isDup) {
+				status = "duplicate";
+			} else {
+				status = "ambiguous";
+			}
+			selectedMatch = matches[0];
+		}
+
+		results.push({
+			raw,
+			format,
+			status,
+			tmdbMatches: matches,
+			selectedMatch,
+			skip: status === "duplicate",
+		});
+
+		onProgress(i + 1, rows.length);
+
+		// Throttle to ~4 req/sec
+		if (i < rows.length - 1) {
+			await new Promise((resolve) => setTimeout(resolve, 250));
+		}
+	}
+
+	return results;
+}
+
+export async function executeImport(
+	rows: ImportRow[],
+): Promise<{ imported: number; skipped: number }> {
+	let imported = 0;
+	let skipped = 0;
+
+	for (const row of rows) {
+		if (row.skip) {
+			skipped++;
+			continue;
+		}
+
+		const match = row.selectedMatch;
+		let posterUrl: string | null = null;
+
+		if (match?.poster_path) {
+			try {
+				posterUrl = await fetchAndCachePoster(match.id, match.poster_path);
+			} catch {
+				// silent — poster missing is non-fatal
+			}
+		}
+
+		const releaseYear =
+			match?.release_date && match.release_date.length >= 4
+				? parseInt(match.release_date.slice(0, 4), 10)
+				: row.raw.year;
+
+		await createMovie({
+			tmdb_id: match?.id ?? null,
+			title: match?.title ?? row.raw.title,
+			year: releaseYear,
+			poster_url: posterUrl,
+			tmdb_rating: match?.vote_average ?? null,
+			personal_rating: null,
+			status: "OWNED",
+			format: row.format,
+			is_physical: 0,
+			is_digital: 1,
+			is_backed_up: 0,
+			notes: null,
+			type: "MOVIE",
+			show_id: null,
+			season_number: null,
+		});
+
+		imported++;
+	}
+
+	return { imported, skipped };
+}

--- a/src/features/import/import.types.ts
+++ b/src/features/import/import.types.ts
@@ -1,0 +1,24 @@
+import type { MovieFormat } from "../movies/movies.types";
+import type { TmdbSearchResult } from "../tmdb/tmdb.types";
+
+export type ImportRowStatus =
+	| "pending"
+	| "ready"
+	| "ambiguous"
+	| "duplicate"
+	| "not_found";
+
+export type RawImportRow = {
+	title: string;
+	year: number;
+	resolution: string;
+};
+
+export type ImportRow = {
+	raw: RawImportRow;
+	format: MovieFormat;
+	status: ImportRowStatus;
+	tmdbMatches: TmdbSearchResult[];
+	selectedMatch: TmdbSearchResult | null;
+	skip: boolean;
+};

--- a/src/features/movies/movies.service.ts
+++ b/src/features/movies/movies.service.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { z } from "zod";
 import { getDb } from "../../lib/db";
 import {
@@ -172,4 +173,36 @@ export async function checkTitleYearSimilar(
 		[title, year],
 	);
 	return (rows[0]?.count ?? 0) > 0;
+}
+
+export async function exportCollectionAsJson(): Promise<void> {
+	const movies = await getAllMovies();
+	const content = JSON.stringify(movies, null, 2);
+	const today = new Date().toISOString().slice(0, 10);
+	await invoke("write_to_downloads", {
+		filename: `moviedb-export-${today}.json`,
+		content,
+	});
+}
+
+export async function exportCollectionAsCsv(): Promise<void> {
+	const movies = await getAllMovies();
+	const header = "title,year,format,status,tmdb_rating,personal_rating";
+	const rows = movies.map((m) => {
+		const cols = [
+			`"${m.title.replace(/"/g, '""')}"`,
+			m.year ?? "",
+			m.format,
+			m.status,
+			m.tmdb_rating ?? "",
+			m.personal_rating ?? "",
+		];
+		return cols.join(",");
+	});
+	const content = [header, ...rows].join("\n");
+	const today = new Date().toISOString().slice(0, 10);
+	await invoke("write_to_downloads", {
+		filename: `moviedb-export-${today}.csv`,
+		content,
+	});
 }

--- a/src/features/tmdb/tmdb.service.ts
+++ b/src/features/tmdb/tmdb.service.ts
@@ -26,6 +26,17 @@ export async function searchMovies(query: string): Promise<TmdbSearchResult[]> {
 	return data.results;
 }
 
+export async function searchMovieByTitleYear(
+	title: string,
+	year: number,
+): Promise<TmdbSearchResult[]> {
+	const url = `${TMDB_BASE}/search/movie?query=${encodeURIComponent(title)}&primary_release_year=${year}&api_key=${TMDB_API_KEY}&language=en-US&page=1`;
+	const res = await fetch(url);
+	if (!res.ok) throw new Error(`TMDB error: ${res.status}`);
+	const data = TmdbSearchResponseSchema.parse(await res.json());
+	return data.results;
+}
+
 /**
  * Fetch and cache a TMDB poster via Rust (reqwest — no CORS restriction).
  * Checks the local poster-cache first; downloads only if not cached.

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,6 +8,7 @@ import { rootRoute } from "./routes/__root";
 import { AddMovieView } from "./views/AddMovieView";
 import { CollectionView } from "./views/CollectionView";
 import { EditMovieView } from "./views/EditMovieView";
+import { ImportView } from "./views/ImportView";
 import { SettingsView } from "./views/SettingsView";
 import { SyncView } from "./views/SyncView";
 
@@ -49,6 +50,12 @@ const syncRoute = createRoute({
 	component: SyncView,
 });
 
+const importRoute = createRoute({
+	getParentRoute: () => rootRoute,
+	path: "/import",
+	component: ImportView,
+});
+
 const routeTree = rootRoute.addChildren([
 	indexRoute,
 	addMovieRoute,
@@ -56,6 +63,7 @@ const routeTree = rootRoute.addChildren([
 	editMovieRoute,
 	settingsRoute,
 	syncRoute,
+	importRoute,
 ]);
 
 const memoryHistory = createMemoryHistory({ initialEntries: ["/"] });

--- a/src/views/ImportView.tsx
+++ b/src/views/ImportView.tsx
@@ -1,0 +1,377 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { Toast } from "@/components/atoms/Toast/toast";
+import {
+	executeImport,
+	parseJellyfinCsv,
+	processImportRows,
+} from "@/features/import/import.service";
+import type { ImportRow } from "@/features/import/import.types";
+import { TMDB_POSTER_BASE } from "@/features/tmdb/tmdb.service";
+import type { TmdbSearchResult } from "@/features/tmdb/tmdb.types";
+
+type Phase = "pick" | "processing" | "review";
+type ReviewTab = "ready" | "duplicates" | "not_found";
+
+export function ImportView() {
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+
+	const [phase, setPhase] = useState<Phase>("pick");
+	const [csvText, setCsvText] = useState("");
+	const [progress, setProgress] = useState({ done: 0, total: 0 });
+	const [rows, setRows] = useState<ImportRow[]>([]);
+	const [activeTab, setActiveTab] = useState<ReviewTab>("ready");
+	const [isImporting, setIsImporting] = useState(false);
+	const [toast, setToast] = useState<{
+		message: string;
+		variant: "success" | "error";
+	} | null>(null);
+
+	function showToast(
+		message: string,
+		variant: "success" | "error" = "success",
+	) {
+		setToast({ message, variant });
+		setTimeout(() => setToast(null), 3000);
+	}
+
+	async function handleProcess() {
+		const rawRows = parseJellyfinCsv(csvText);
+
+		if (rawRows.length === 0) {
+			showToast("No valid rows found — check the format", "error");
+			return;
+		}
+
+		setProgress({ done: 0, total: rawRows.length });
+		setPhase("processing");
+
+		const processed = await processImportRows(rawRows, (done, total) => {
+			setProgress({ done, total });
+		});
+
+		setRows(processed);
+		setActiveTab("ready");
+		setPhase("review");
+	}
+
+	function toggleSkip(index: number) {
+		setRows((prev) =>
+			prev.map((r, i) => (i === index ? { ...r, skip: !r.skip } : r)),
+		);
+	}
+
+	function selectMatch(index: number, match: TmdbSearchResult) {
+		setRows((prev) =>
+			prev.map((r, i) =>
+				i === index ? { ...r, selectedMatch: match, status: "ready" } : r,
+			),
+		);
+	}
+
+	async function handleConfirm() {
+		setIsImporting(true);
+		try {
+			const { imported, skipped } = await executeImport(rows);
+			await queryClient.invalidateQueries({ queryKey: ["movies"] });
+			showToast(
+				`Imported ${imported} movie${imported === 1 ? "" : "s"}${skipped > 0 ? `, skipped ${skipped}` : ""}`,
+			);
+			setTimeout(() => navigate({ to: "/" }), 1500);
+		} catch {
+			showToast("Import failed", "error");
+			setIsImporting(false);
+		}
+	}
+
+	const readyRows = rows
+		.map((r, i) => ({ row: r, index: i }))
+		.filter(({ row }) => row.status === "ready" || row.status === "ambiguous");
+	const duplicateRows = rows
+		.map((r, i) => ({ row: r, index: i }))
+		.filter(({ row }) => row.status === "duplicate");
+	const notFoundRows = rows
+		.map((r, i) => ({ row: r, index: i }))
+		.filter(({ row }) => row.status === "not_found");
+
+	const importCount = rows.filter((r) => !r.skip).length;
+
+	return (
+		<div className="flex h-full flex-col bg-gray-950 text-white">
+			<Toast
+				message={toast?.message ?? ""}
+				visible={toast !== null}
+				variant={toast?.variant}
+			/>
+
+			{/* Header */}
+			<div className="flex items-center gap-3 border-b border-white/10 p-4">
+				<button
+					type="button"
+					className="text-blue-400 text-sm"
+					onClick={() => navigate({ to: "/" })}
+				>
+					Cancel
+				</button>
+				<h1 className="flex-1 text-center text-base font-semibold">
+					Import from Jellyfin CSV
+				</h1>
+				<div className="w-12" />
+			</div>
+
+			{/* Pick phase */}
+			{phase === "pick" && (
+				<div className="flex flex-1 flex-col gap-4 p-4">
+					<p className="text-xs text-white/40">
+						Paste your Jellyfin CSV below. Expected format:
+					</p>
+					<pre className="rounded-lg bg-white/5 px-3 py-2 text-xs text-white/30">
+						{"Name,Year,Resolution\nThe Matrix,1999,1920 * 800"}
+					</pre>
+					<textarea
+						className="flex-1 resize-none rounded-xl border border-white/10 bg-gray-900 p-3 text-sm text-white placeholder-white/20 outline-none focus:border-blue-500"
+						placeholder="Name,Year,Resolution&#10;The Matrix,1999,1920 * 800&#10;Inception,2010,3840 * 1600"
+						value={csvText}
+						onChange={(e) => setCsvText(e.target.value)}
+						spellCheck={false}
+						autoCorrect="off"
+						autoCapitalize="off"
+					/>
+					<button
+						type="button"
+						disabled={csvText.trim().length === 0}
+						className="rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white transition-opacity active:opacity-70 disabled:opacity-40"
+						onClick={handleProcess}
+					>
+						Search TMDB
+					</button>
+				</div>
+			)}
+
+			{/* Processing phase */}
+			{phase === "processing" && (
+				<div className="flex flex-1 flex-col items-center justify-center gap-4 p-8">
+					<p className="text-sm text-white/60">Searching TMDB…</p>
+					<p className="text-lg font-semibold">
+						{progress.done} of {progress.total}
+					</p>
+					<div className="h-2 w-full max-w-sm overflow-hidden rounded-full bg-white/10">
+						<div
+							className="h-full rounded-full bg-blue-500 transition-all duration-200"
+							style={{
+								width:
+									progress.total > 0
+										? `${(progress.done / progress.total) * 100}%`
+										: "0%",
+							}}
+						/>
+					</div>
+				</div>
+			)}
+
+			{/* Review phase */}
+			{phase === "review" && (
+				<>
+					{/* Tab bar */}
+					<div className="flex border-b border-white/10">
+						{(
+							[
+								{
+									key: "ready" as ReviewTab,
+									label: "Ready",
+									count: readyRows.length,
+								},
+								{
+									key: "duplicates" as ReviewTab,
+									label: "Duplicates",
+									count: duplicateRows.length,
+								},
+								{
+									key: "not_found" as ReviewTab,
+									label: "Not found",
+									count: notFoundRows.length,
+								},
+							] as const
+						).map(({ key, label, count }) => (
+							<button
+								key={key}
+								type="button"
+								className={`flex-1 py-3 text-xs font-semibold transition-colors ${
+									activeTab === key
+										? "border-b-2 border-blue-500 text-blue-400"
+										: "text-white/40"
+								}`}
+								onClick={() => setActiveTab(key)}
+							>
+								{label} ({count})
+							</button>
+						))}
+					</div>
+
+					{/* Tab content */}
+					<div className="flex-1 overflow-y-auto">
+						{activeTab === "ready" && (
+							<ul className="divide-y divide-white/5">
+								{readyRows.length === 0 && (
+									<li className="p-6 text-center text-sm text-white/30">
+										No matches
+									</li>
+								)}
+								{readyRows.map(({ row, index }) => (
+									<li key={index} className="p-4">
+										<div className="flex items-start gap-3">
+											{/* Poster thumbnail */}
+											{row.selectedMatch?.poster_path ? (
+												<img
+													src={`${TMDB_POSTER_BASE}${row.selectedMatch.poster_path}`}
+													alt=""
+													className="h-16 w-11 shrink-0 rounded object-cover"
+												/>
+											) : (
+												<div className="h-16 w-11 shrink-0 rounded bg-white/10" />
+											)}
+											<div className="min-w-0 flex-1">
+												<p className="truncate text-sm font-medium">
+													{row.selectedMatch?.title ?? row.raw.title}
+												</p>
+												<p className="text-xs text-white/40">
+													{row.selectedMatch?.release_date?.slice(0, 4) ??
+														row.raw.year}{" "}
+													· {row.format}
+												</p>
+												{/* Ambiguous picker */}
+												{row.status === "ambiguous" && (
+													<div className="mt-2">
+														<p className="mb-1 text-xs text-amber-400">
+															Multiple matches — tap to select:
+														</p>
+														<div className="flex gap-2 overflow-x-auto pb-1">
+															{row.tmdbMatches.map((match) => (
+																<button
+																	key={match.id}
+																	type="button"
+																	className={`shrink-0 rounded-lg border p-1.5 text-left transition-colors ${
+																		row.selectedMatch?.id === match.id
+																			? "border-blue-500 bg-blue-500/10"
+																			: "border-white/10 bg-white/5"
+																	}`}
+																	onClick={() => selectMatch(index, match)}
+																>
+																	{match.poster_path ? (
+																		<img
+																			src={`${TMDB_POSTER_BASE}${match.poster_path}`}
+																			alt=""
+																			className="h-14 w-10 rounded object-cover"
+																		/>
+																	) : (
+																		<div className="h-14 w-10 rounded bg-white/10" />
+																	)}
+																	<p className="mt-1 w-10 truncate text-center text-xs text-white/60">
+																		{match.release_date?.slice(0, 4)}
+																	</p>
+																</button>
+															))}
+														</div>
+													</div>
+												)}
+											</div>
+										</div>
+									</li>
+								))}
+							</ul>
+						)}
+
+						{activeTab === "duplicates" && (
+							<ul className="divide-y divide-white/5">
+								{duplicateRows.length === 0 && (
+									<li className="p-6 text-center text-sm text-white/30">
+										No duplicates
+									</li>
+								)}
+								{duplicateRows.map(({ row, index }) => (
+									<li key={index} className="flex items-center gap-3 p-4">
+										{row.selectedMatch?.poster_path ? (
+											<img
+												src={`${TMDB_POSTER_BASE}${row.selectedMatch.poster_path}`}
+												alt=""
+												className="h-16 w-11 shrink-0 rounded object-cover"
+											/>
+										) : (
+											<div className="h-16 w-11 shrink-0 rounded bg-white/10" />
+										)}
+										<div className="min-w-0 flex-1">
+											<p className="truncate text-sm font-medium">
+												{row.selectedMatch?.title ?? row.raw.title}
+											</p>
+											<p className="text-xs text-white/40">
+												{row.raw.year} · {row.format}
+											</p>
+											<p className="mt-0.5 text-xs text-white/30">
+												Already in collection
+											</p>
+										</div>
+										<button
+											type="button"
+											className={`shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
+												row.skip
+													? "bg-white/10 text-white/40"
+													: "bg-blue-600 text-white"
+											}`}
+											onClick={() => toggleSkip(index)}
+										>
+											{row.skip ? "Skip" : "Add"}
+										</button>
+									</li>
+								))}
+							</ul>
+						)}
+
+						{activeTab === "not_found" && (
+							<>
+								<p className="px-4 pt-3 text-xs text-white/40">
+									These will be imported as manual entries (title + year only).
+								</p>
+								<ul className="divide-y divide-white/5">
+									{notFoundRows.length === 0 && (
+										<li className="p-6 text-center text-sm text-white/30">
+											None
+										</li>
+									)}
+									{notFoundRows.map(({ row, index }) => (
+										<li key={index} className="flex items-center gap-3 p-4">
+											<div className="h-16 w-11 shrink-0 rounded bg-white/10" />
+											<div className="min-w-0 flex-1">
+												<p className="truncate text-sm font-medium">
+													{row.raw.title}
+												</p>
+												<p className="text-xs text-white/40">
+													{row.raw.year} · {row.format}
+												</p>
+											</div>
+										</li>
+									))}
+								</ul>
+							</>
+						)}
+					</div>
+
+					{/* Footer */}
+					<div className="border-t border-white/10 p-4 pb-[calc(env(safe-area-inset-bottom)+16px)]">
+						<button
+							type="button"
+							disabled={isImporting || importCount === 0}
+							className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white transition-opacity active:opacity-70 disabled:opacity-40"
+							onClick={handleConfirm}
+						>
+							{isImporting
+								? "Importing…"
+								: `Import ${importCount} movie${importCount === 1 ? "" : "s"}`}
+						</button>
+					</div>
+				</>
+			)}
+		</div>
+	);
+}

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -1,7 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { Toast } from "../components/atoms/Toast/toast";
 import { ConfirmSheet } from "../components/molecules/ConfirmSheet/confirm-sheet";
+import {
+	exportCollectionAsCsv,
+	exportCollectionAsJson,
+} from "../features/movies/movies.service";
 import {
 	clearPosterCache,
 	getPosterCacheSize,
@@ -18,6 +23,7 @@ function formatBytes(bytes: number): string {
 
 export function SettingsView() {
 	const queryClient = useQueryClient();
+	const navigate = useNavigate();
 
 	// PocketBase URL
 	const [pbUrl, setPbUrl] = useState(
@@ -73,6 +79,18 @@ export function SettingsView() {
 			);
 		},
 		onError: () => showToast("Failed to refresh posters", "error"),
+	});
+
+	const { mutate: doExportJson, isPending: isExportingJson } = useMutation({
+		mutationFn: exportCollectionAsJson,
+		onSuccess: () => showToast("Exported to Downloads"),
+		onError: () => showToast("Export failed", "error"),
+	});
+
+	const { mutate: doExportCsv, isPending: isExportingCsv } = useMutation({
+		mutationFn: exportCollectionAsCsv,
+		onSuccess: () => showToast("Exported to Downloads"),
+		onError: () => showToast("Export failed", "error"),
 	});
 
 	return (
@@ -162,6 +180,40 @@ export function SettingsView() {
 							onClick={() => setShowClearConfirm(true)}
 						>
 							Clear Poster Cache
+						</button>
+					</div>
+				</section>
+
+				{/* Collection */}
+				<section className="flex flex-col gap-3">
+					<h2 className="text-xs font-semibold uppercase tracking-widest text-white/40">
+						Collection
+					</h2>
+					<div className="rounded-2xl border border-white/10 bg-gray-900">
+						<button
+							type="button"
+							disabled={isExportingJson}
+							className="w-full px-4 py-3.5 text-left text-sm font-medium text-blue-400 transition-opacity active:opacity-70 disabled:opacity-40"
+							onClick={() => doExportJson()}
+						>
+							{isExportingJson ? "Exporting…" : "Export as JSON"}
+						</button>
+						<div className="h-px bg-white/10" />
+						<button
+							type="button"
+							disabled={isExportingCsv}
+							className="w-full px-4 py-3.5 text-left text-sm font-medium text-blue-400 transition-opacity active:opacity-70 disabled:opacity-40"
+							onClick={() => doExportCsv()}
+						>
+							{isExportingCsv ? "Exporting…" : "Export as CSV"}
+						</button>
+						<div className="h-px bg-white/10" />
+						<button
+							type="button"
+							className="w-full px-4 py-3.5 text-left text-sm font-medium text-blue-400 transition-opacity active:opacity-70"
+							onClick={() => navigate({ to: "/import" })}
+						>
+							Import from Jellyfin CSV
 						</button>
 					</div>
 				</section>


### PR DESCRIPTION
- Parse Jellyfin CSV (Name,Year,Resolution) via paste textarea
- TMDB search per row throttled ~4 req/sec with progress bar
- Review screen: Ready / Duplicates / Not found tabs with per-item skip toggle
- Ambiguous TMDB matches surface inline horizontal picker
- Export collection as JSON or CSV to device Downloads (new write_to_downloads Rust command)
- Import/Export buttons in Settings → Collection section
- Add WRITE_EXTERNAL_STORAGE manifest permission for Android < 10