### PR TITLE
feat: inline TMDB autocomplete, sync detail logs, 3-state copy filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ GitHub Issues is the task management system for this project (repo: `sethgo88/mo
 ### Workflow
 1. Before starting any new work, run `list issues` to check open issues and current priorities
 2. Never start work without a corresponding issue — create one first if it doesn't exist
-3. **Before touching any file, create or checkout the branch for the issue.** Run `git branch --show-current`; if on `master`, run `git checkout -b feat/<description>` (or `fix/`, `phase/` as appropriate). If a branch for the issue already exists, check it out instead.
+3. **Before touching any file, create or checkout the branch for the issue.** Run `git branch --show-current`; if on `master`, run `git new feat/<description>` (or `fix/`, `phase/` as appropriate). If a branch for the issue already exists, check it out instead.
 4. Reference the issue number in every commit message (e.g. `feat: add poster cache, closes #14`)
 5. When a task is complete, close the issue and leave a brief comment summarising what was done
 6. If work reveals new tasks or edge cases, open new issues rather than expanding scope of the current one

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,10 +13,7 @@
 		"http:default",
 		{
 			"identifier": "http:allow-fetch",
-			"allow": [
-				{ "url": "http://*:*/**" },
-				{ "url": "https://*:*/**" }
-			]
+			"allow": [{ "url": "http://*:*/**" }, { "url": "https://*:*/**" }]
 		}
 	]
 }

--- a/src/components/organisms/MovieForm/movie-form.tsx
+++ b/src/components/organisms/MovieForm/movie-form.tsx
@@ -1,6 +1,5 @@
 import { useForm } from "@tanstack/react-form";
 import { useBlocker, useNavigate, useParams } from "@tanstack/react-router";
-import { Search } from "lucide-react";
 import { useState } from "react";
 import { z } from "zod";
 import {
@@ -11,16 +10,19 @@ import type {
 	MovieFormat,
 	MovieStatus,
 } from "../../../features/movies/movies.types";
+import { useTmdbSearch } from "../../../features/tmdb/tmdb.queries";
+import {
+	fetchAndCachePoster,
+	TMDB_POSTER_BASE,
+} from "../../../features/tmdb/tmdb.service";
 import type { TmdbSearchResult } from "../../../features/tmdb/tmdb.types";
 import { PosterPicker } from "../../atoms/PosterPicker/poster-picker";
 import { Select } from "../../atoms/Select/select";
 import { Slider } from "../../atoms/Slider/slider";
 import { Spinner } from "../../atoms/Spinner/spinner";
-import { Toast } from "../../atoms/Toast/toast";
 import { Toggle } from "../../atoms/Toggle/toggle";
 import { ConfirmSheet } from "../../molecules/ConfirmSheet/confirm-sheet";
 import { FormField } from "../../molecules/FormField/form-field";
-import { TmdbSearch } from "../../molecules/TmdbSearch/tmdb-search";
 import { ToggleGroup } from "../../molecules/ToggleGroup/toggle-group";
 
 const STATUS_OPTIONS: { label: string; value: MovieStatus }[] = [
@@ -99,17 +101,15 @@ export function MovieForm({
 	const { data: movie, isLoading } = useMovie(id);
 	const { mutate: softDelete, isPending: isDeleting } = useSoftDeleteMovie();
 	const [showDelete, setShowDelete] = useState(false);
-	const [showTmdbSearch, setShowTmdbSearch] = useState(false);
-	const [tmdbToast, setTmdbToast] = useState<{
-		message: string;
-		variant: "success" | "error";
-	} | null>(null);
 
-	// Router-level blocker — intercepts all navigation (NavBar, back gesture,
-	// programmatic navigate) when the form is dirty.
-	// Exclude isSubmitting: navigation triggered inside onSubmit (e.g. navigate
-	// after createMovie/updateMovie) must not be blocked — formApi.reset() hasn't
-	// run yet so isDirty is still true at that moment.
+	const [titleQuery, setTitleQuery] = useState("");
+	const [isTitleFocused, setIsTitleFocused] = useState(false);
+	const [loadingId, setLoadingId] = useState<number | null>(null);
+
+	const { data: searchResults } = useTmdbSearch(titleQuery);
+	const showDropdown =
+		isTitleFocused && !!searchResults && searchResults.length > 0;
+
 	const blocker = useBlocker({
 		shouldBlockFn: () => form.state.isDirty && !form.state.isSubmitting,
 		withResolver: true,
@@ -133,7 +133,17 @@ export function MovieForm({
 		});
 	}
 
-	function handleTmdbSelect(result: TmdbSearchResult, url: string | null) {
+	async function handleSelectResult(result: TmdbSearchResult) {
+		setLoadingId(result.id);
+		let posterUrl: string | null = null;
+		if (result.poster_path) {
+			try {
+				posterUrl = await fetchAndCachePoster(result.id, result.poster_path);
+			} catch {
+				// poster unavailable — other fields still applied
+			}
+		}
+		setLoadingId(null);
 		form.setFieldValue("title", result.title);
 		if (result.release_date) {
 			form.setFieldValue("year", result.release_date.slice(0, 4));
@@ -143,12 +153,9 @@ export function MovieForm({
 			"tmdb_rating",
 			result.vote_average > 0 ? result.vote_average : null,
 		);
-		if (url) {
-			form.setFieldValue("poster_url", url);
-		}
-		setShowTmdbSearch(false);
-		setTmdbToast({ message: "TMDB data applied", variant: "success" });
-		setTimeout(() => setTmdbToast(null), 3000);
+		if (posterUrl) form.setFieldValue("poster_url", posterUrl);
+		setTitleQuery("");
+		setIsTitleFocused(false);
 	}
 
 	return (
@@ -159,14 +166,6 @@ export function MovieForm({
 					Back
 				</button>
 				<h1 className="flex-1 text-center text-lg font-semibold">{title}</h1>
-				<button
-					type="button"
-					aria-label="Search TMDB"
-					className="mr-2 text-white/50"
-					onClick={() => setShowTmdbSearch(true)}
-				>
-					<Search size={20} />
-				</button>
 				<form.Subscribe selector={(s) => s.isSubmitting}>
 					{(isSubmitting) => (
 						<button
@@ -189,7 +188,104 @@ export function MovieForm({
 					}}
 					className="flex flex-col gap-5"
 				>
-					{/* Poster + Title/Year row */}
+					{/* Title with inline TMDB autocomplete */}
+					<form.Field
+						name="title"
+						validators={{
+							onBlur: ({ value }) => {
+								const result = z
+									.string()
+									.min(1, "Title is required")
+									.safeParse(value);
+								return result.success
+									? undefined
+									: result.error.issues[0]?.message;
+							},
+						}}
+					>
+						{(field) => (
+							<FormField
+								label="Title *"
+								error={field.state.meta.errors[0]?.toString()}
+							>
+								<div className="relative">
+									<input
+										value={field.state.value}
+										placeholder="Movie title"
+										className="w-full rounded-lg border border-white/10 bg-gray-800 px-3 py-2.5 text-white placeholder-white/30 outline-none transition-colors focus:border-blue-500"
+										onChange={(e) => {
+											field.handleChange(e.target.value);
+											setTitleQuery(e.target.value);
+										}}
+										onFocus={() => setIsTitleFocused(true)}
+										onBlur={() => {
+											field.handleBlur();
+											setTimeout(() => setIsTitleFocused(false), 150);
+										}}
+									/>
+									{showDropdown && (
+										<ul className="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 overflow-y-auto rounded-lg border border-white/10 bg-gray-800 shadow-xl">
+											{(searchResults ?? []).map((result) => {
+												const year = result.release_date?.slice(0, 4);
+												const isLoading = loadingId === result.id;
+												return (
+													<li key={result.id}>
+														<button
+															type="button"
+															disabled={loadingId !== null}
+															className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors active:bg-white/5 disabled:opacity-50"
+															onMouseDown={(e) => e.preventDefault()}
+															onClick={() => handleSelectResult(result)}
+														>
+															<div className="h-12 w-8 shrink-0 overflow-hidden rounded bg-white/10">
+																{result.poster_path ? (
+																	<img
+																		src={`${TMDB_POSTER_BASE}${result.poster_path}`}
+																		alt={result.title}
+																		className="h-full w-full object-cover"
+																	/>
+																) : (
+																	<div className="h-full w-full" />
+																)}
+															</div>
+															<div className="min-w-0 flex-1">
+																<p className="truncate text-sm font-medium text-white">
+																	{result.title}
+																</p>
+																{year && (
+																	<p className="text-xs text-white/50">{year}</p>
+																)}
+															</div>
+															{isLoading && (
+																<span className="text-xs text-white/40">
+																	Loading…
+																</span>
+															)}
+														</button>
+													</li>
+												);
+											})}
+										</ul>
+									)}
+								</div>
+							</FormField>
+						)}
+					</form.Field>
+
+					{/* Year */}
+					<form.Field name="year">
+						{(field) => (
+							<FormField label="Year">
+								<Select
+									options={YEAR_OPTIONS}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+								/>
+							</FormField>
+						)}
+					</form.Field>
+
+					{/* Poster + Physical/Digital */}
 					<div className="flex gap-4">
 						<form.Field name="poster_url">
 							{(field) => (
@@ -199,49 +295,25 @@ export function MovieForm({
 								/>
 							)}
 						</form.Field>
-
-						<div className="flex flex-1 flex-col gap-3">
-							{/* Title */}
-							<form.Field
-								name="title"
-								validators={{
-									onBlur: ({ value }) => {
-										const result = z
-											.string()
-											.min(1, "Title is required")
-											.safeParse(value);
-										return result.success
-											? undefined
-											: result.error.issues[0]?.message;
-									},
-								}}
-							>
+						<div className="flex flex-1 flex-col justify-center gap-4 rounded-lg border border-white/10 p-4">
+							<form.Field name="is_physical">
 								{(field) => (
-									<FormField
-										label="Title *"
-										error={field.state.meta.errors[0]?.toString()}
-									>
-										<input
-											value={field.state.value}
-											placeholder="Movie title"
-											className="w-full rounded-lg border border-white/10 bg-gray-800 px-3 py-2.5 text-white placeholder-white/30 outline-none transition-colors focus:border-blue-500"
-											onChange={(e) => field.handleChange(e.target.value)}
-											onBlur={field.handleBlur}
-										/>
-									</FormField>
+									<Toggle
+										checked={field.state.value}
+										onChange={(v) => field.handleChange(v)}
+										label="Physical copy"
+										vertical
+									/>
 								)}
 							</form.Field>
-
-							{/* Year */}
-							<form.Field name="year">
+							<form.Field name="is_digital">
 								{(field) => (
-									<FormField label="Year">
-										<Select
-											options={YEAR_OPTIONS}
-											value={field.state.value}
-											onChange={(e) => field.handleChange(e.target.value)}
-										/>
-									</FormField>
+									<Toggle
+										checked={field.state.value}
+										onChange={(v) => field.handleChange(v)}
+										label="Digital copy"
+										vertical
+									/>
 								)}
 							</form.Field>
 						</div>
@@ -259,30 +331,6 @@ export function MovieForm({
 							</FormField>
 						)}
 					</form.Field>
-
-					{/* Copy type toggles */}
-					<div className="flex justify-around gap-4 rounded-lg border border-white/10 p-4">
-						<form.Field name="is_physical">
-							{(field) => (
-								<Toggle
-									checked={field.state.value}
-									onChange={(v) => field.handleChange(v)}
-									label="Physical copy"
-									vertical
-								/>
-							)}
-						</form.Field>
-						<form.Field name="is_digital">
-							{(field) => (
-								<Toggle
-									checked={field.state.value}
-									onChange={(v) => field.handleChange(v)}
-									label="Digital copy"
-									vertical
-								/>
-							)}
-						</form.Field>
-					</div>
 
 					{/* Format */}
 					<form.Field name="format">
@@ -350,9 +398,9 @@ export function MovieForm({
 						)}
 					</form.Field>
 				</form>
+
 				{movie && (
 					<div>
-						{/* Delete */}
 						<div className="border-t border-white/10 p-4">
 							<button
 								type="button"
@@ -377,12 +425,6 @@ export function MovieForm({
 				)}
 			</div>
 
-			<Toast
-				message={tmdbToast?.message ?? ""}
-				visible={tmdbToast !== null}
-				variant={tmdbToast?.variant}
-			/>
-
 			<ConfirmSheet
 				isOpen={blocker.status === "blocked"}
 				title="Discard Changes"
@@ -396,12 +438,6 @@ export function MovieForm({
 					await form.handleSubmit();
 					blocker.proceed?.();
 				}}
-			/>
-
-			<TmdbSearch
-				isOpen={showTmdbSearch}
-				onClose={() => setShowTmdbSearch(false)}
-				onSelect={handleTmdbSelect}
 			/>
 		</div>
 	);

--- a/src/components/organisms/MovieForm/movie-form.tsx
+++ b/src/components/organisms/MovieForm/movie-form.tsx
@@ -253,7 +253,9 @@ export function MovieForm({
 																	{result.title}
 																</p>
 																{year && (
-																	<p className="text-xs text-white/50">{year}</p>
+																	<p className="text-xs text-white/50">
+																		{year}
+																	</p>
 																)}
 															</div>
 															{isLoading && (

--- a/src/features/sync/sync.schema.ts
+++ b/src/features/sync/sync.schema.ts
@@ -59,8 +59,15 @@ export const PbMovieRecordSchema = z.object({
 	season_number: pbNullableInt,
 });
 
+const SyncedMovieSchema = z.object({
+	id: z.string(),
+	title: z.string(),
+});
+
 export const SyncResultSchema = z.object({
-	pushed: z.number().int(),
-	pulled: z.number().int(),
+	pushedMovies: z.array(SyncedMovieSchema),
+	pulledMovies: z.array(SyncedMovieSchema),
+	deletedMovies: z.array(SyncedMovieSchema),
+	dedupedMovies: z.array(SyncedMovieSchema),
 	errors: z.array(z.string()),
 });

--- a/src/features/sync/sync.service.ts
+++ b/src/features/sync/sync.service.ts
@@ -163,7 +163,9 @@ export async function runSync(
 				}
 				await db.execute("DELETE FROM movies WHERE id = $1", [stray.id]);
 				dedupedMovies.push({ id: stray.id, title: stray.title });
-				console.log(`[sync] dedup: removed stray "${stray.title}" (${stray.id})`);
+				console.log(
+					`[sync] dedup: removed stray "${stray.title}" (${stray.id})`,
+				);
 			}
 		}
 

--- a/src/features/sync/sync.service.ts
+++ b/src/features/sync/sync.service.ts
@@ -63,8 +63,10 @@ export async function runSync(
 	const syncStartedAt = new Date().toISOString();
 
 	const errors: string[] = [];
-	let pushed = 0;
-	let pulled = 0;
+	const pushedMovies: { id: string; title: string }[] = [];
+	const pulledMovies: { id: string; title: string }[] = [];
+	const deletedMovies: { id: string; title: string }[] = [];
+	const dedupedMovies: { id: string; title: string }[] = [];
 
 	try {
 		const pb = getPb();
@@ -88,8 +90,8 @@ export async function runSync(
 
 		// --- PUSH DELETES ---
 		if (pendingCount > 0) {
-			const softDeleted = await db.select<{ id: string }[]>(
-				"SELECT id FROM movies WHERE deleted_at IS NOT NULL",
+			const softDeleted = await db.select<{ id: string; title: string }[]>(
+				"SELECT id, title FROM movies WHERE deleted_at IS NOT NULL",
 			);
 
 			for (const row of softDeleted) {
@@ -104,11 +106,64 @@ export async function runSync(
 					}
 
 					await db.execute("DELETE FROM movies WHERE id = $1", [row.id]);
+					deletedMovies.push({ id: row.id, title: row.title });
 				} catch (e) {
 					const msg = `Failed to delete movie ${row.id}: ${String(e)}`;
 					console.error("[sync] delete error:", msg, e);
 					errors.push(msg);
 				}
+			}
+		}
+
+		// Build the PocketBase id map early so we can use it during local dedup.
+		const allPbRecords = await pb.collection("movies").getFullList();
+		const pbIdMap = new Map(
+			allPbRecords.map((r) => [r.local_id as string, r.id]),
+		);
+
+		// --- LOCAL DEDUP ---
+		// If the same TMDB title was ever added twice (different UUIDs), the pull
+		// dedup treats each as a stray of the other and deletes both PB records
+		// every pull cycle, causing an endless push-every-other-sync loop.
+		// Fix: before pushing, find (tmdb_id, type, season_number) groups with
+		// more than one active local record, keep the most-recently-updated one,
+		// and hard-delete the rest from both SQLite and PocketBase.
+		const dupeGroups = await db.select<
+			{ tmdb_id: number; type: string; sn: number }[]
+		>(
+			`SELECT tmdb_id, type, COALESCE(season_number, -1) AS sn
+			 FROM movies
+			 WHERE deleted_at IS NULL AND tmdb_id IS NOT NULL
+			 GROUP BY tmdb_id, type, COALESCE(season_number, -1)
+			 HAVING COUNT(*) > 1`,
+		);
+
+		for (const group of dupeGroups) {
+			const members = await db.select<
+				{ id: string; title: string; updated_at: string }[]
+			>(
+				`SELECT id, title, updated_at FROM movies
+				 WHERE tmdb_id = $1 AND type = $2
+				   AND COALESCE(season_number, -1) = $3
+				   AND deleted_at IS NULL
+				 ORDER BY updated_at DESC, id ASC`,
+				[group.tmdb_id, group.type, group.sn],
+			);
+			// First row is the keeper (latest updated_at); delete the rest.
+			const [, ...strays] = members;
+			for (const stray of strays) {
+				const pbId = pbIdMap.get(stray.id);
+				if (pbId) {
+					try {
+						await pb.collection("movies").delete(pbId);
+					} catch {
+						// best-effort — may already be gone
+					}
+					pbIdMap.delete(stray.id);
+				}
+				await db.execute("DELETE FROM movies WHERE id = $1", [stray.id]);
+				dedupedMovies.push({ id: stray.id, title: stray.title });
+				console.log(`[sync] dedup: removed stray "${stray.title}" (${stray.id})`);
 			}
 		}
 
@@ -119,11 +174,6 @@ export async function runSync(
 		// were never successfully pushed.
 		const localRows = await db.select<Record<string, unknown>[]>(
 			"SELECT * FROM movies WHERE deleted_at IS NULL",
-		);
-
-		const allPbRecords = await pb.collection("movies").getFullList();
-		const pbIdMap = new Map(
-			allPbRecords.map((r) => [r.local_id as string, r.id]),
 		);
 
 		// Track pushed local_ids so the pull step can skip them — avoids
@@ -174,7 +224,10 @@ export async function runSync(
 					}
 
 					pushedLocalIds.add(row.id as string);
-					pushed++;
+					pushedMovies.push({
+						id: row.id as string,
+						title: row.title as string,
+					});
 				} catch (e) {
 					const msg = `Failed to push movie ${String(row.id)}: ${String(e)}`;
 					console.error("[sync] push error:", msg, e);
@@ -293,7 +346,7 @@ export async function runSync(
 						validated.season_number,
 					],
 				);
-				pulled++;
+				pulledMovies.push({ id: validated.local_id, title: validated.title });
 			} catch (e) {
 				const msg = `Failed to pull record ${record.id}: ${String(e)}`;
 				console.error("[sync] pull error:", msg, e);
@@ -306,7 +359,13 @@ export async function runSync(
 		setLastSyncedAt(syncStartedAt);
 		setPendingDeletes(0);
 
-		return SyncResultSchema.parse({ pushed, pulled, errors });
+		return SyncResultSchema.parse({
+			pushedMovies,
+			pulledMovies,
+			deletedMovies,
+			dedupedMovies,
+			errors,
+		});
 	} catch (e) {
 		if (e instanceof PendingDeletesError) throw e;
 		const msg = e instanceof Error ? e.message : String(e);

--- a/src/views/CollectionView.tsx
+++ b/src/views/CollectionView.tsx
@@ -53,6 +53,7 @@ const chipBase =
 	"shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors";
 const chipActive = "border-blue-500 bg-blue-600 text-white";
 const chipInactive = "border-white/15 bg-white/5 text-white/60";
+const chipHidden = "border-red-400/50 bg-red-400/10 text-red-400";
 
 function sortMovies(movies: Movie[], sortBy: SortOption): Movie[] {
 	return [...movies].sort((a, b) => {
@@ -263,10 +264,16 @@ export function CollectionView() {
 							<button
 								key={key}
 								type="button"
-								onClick={() => setter(active === true ? null : true)}
+								onClick={() =>
+								setter(active === null ? true : active === true ? false : null)
+							}
 								className={cn(
 									chipBase,
-									active === true ? chipActive : chipInactive,
+									active === true
+									? chipActive
+									: active === false
+										? chipHidden
+										: chipInactive,
 								)}
 							>
 								{label}

--- a/src/views/CollectionView.tsx
+++ b/src/views/CollectionView.tsx
@@ -265,15 +265,17 @@ export function CollectionView() {
 								key={key}
 								type="button"
 								onClick={() =>
-								setter(active === null ? true : active === true ? false : null)
-							}
+									setter(
+										active === null ? true : active === true ? false : null,
+									)
+								}
 								className={cn(
 									chipBase,
 									active === true
-									? chipActive
-									: active === false
-										? chipHidden
-										: chipInactive,
+										? chipActive
+										: active === false
+											? chipHidden
+											: chipInactive,
 								)}
 							>
 								{label}

--- a/src/views/SyncView.tsx
+++ b/src/views/SyncView.tsx
@@ -131,12 +131,14 @@ function SyncControls({ onLogout }: { onLogout: () => void }) {
 		}
 		runSync(false, {
 			onSuccess: (result) => {
-				const parts = [];
-				if (result.pushed > 0) parts.push(`↑ ${result.pushed}`);
-				if (result.pulled > 0) parts.push(`↓ ${result.pulled}`);
+				const total =
+					result.pushedMovies.length +
+					result.pulledMovies.length +
+					result.deletedMovies.length +
+					result.dedupedMovies.length;
 				showToast(
-					parts.length > 0
-						? `Synced — ${parts.join("  ")}`
+					total > 0
+						? `Synced ${total} item${total === 1 ? "" : "s"}`
 						: "Already up to date",
 				);
 			},
@@ -150,12 +152,14 @@ function SyncControls({ onLogout }: { onLogout: () => void }) {
 		setShowDeleteConfirm(false);
 		runSync(true, {
 			onSuccess: (result) => {
-				const parts = [];
-				if (result.pushed > 0) parts.push(`↑ ${result.pushed}`);
-				if (result.pulled > 0) parts.push(`↓ ${result.pulled}`);
+				const total =
+					result.pushedMovies.length +
+					result.pulledMovies.length +
+					result.deletedMovies.length +
+					result.dedupedMovies.length;
 				showToast(
-					parts.length > 0
-						? `Synced — ${parts.join("  ")}`
+					total > 0
+						? `Synced ${total} item${total === 1 ? "" : "s"}`
 						: "Already up to date",
 				);
 			},
@@ -164,6 +168,14 @@ function SyncControls({ onLogout }: { onLogout: () => void }) {
 			},
 		});
 	}
+
+	const hasAnyResult =
+		syncResult &&
+		(syncResult.pulledMovies.length > 0 ||
+			syncResult.pushedMovies.length > 0 ||
+			syncResult.deletedMovies.length > 0 ||
+			syncResult.dedupedMovies.length > 0 ||
+			syncResult.errors.length > 0);
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -221,38 +233,94 @@ function SyncControls({ onLogout }: { onLogout: () => void }) {
 					</>
 				)}
 
-				{/* Last sync result */}
+				{/* Last sync result — stacked lists */}
 				{syncResult && !isSyncing && (
 					<>
-						<div className="h-px bg-white/10" />
-						<div className="flex gap-6 px-4 py-3">
-							<div className="text-center">
-								<p className="text-sm font-semibold text-white">
-									{syncResult.pushed}
-								</p>
-								<p className="text-xs text-white/40">Pushed</p>
-							</div>
-							<div className="text-center">
-								<p className="text-sm font-semibold text-white">
-									{syncResult.pulled}
-								</p>
-								<p className="text-xs text-white/40">Pulled</p>
-							</div>
-							{syncResult.errors.length > 0 && (
-								<div className="text-center">
-									<p className="text-sm font-semibold text-red-400">
-										{syncResult.errors.length}
+						{syncResult.pulledMovies.length > 0 && (
+							<>
+								<div className="h-px bg-white/10" />
+								<div className="px-4 py-3">
+									<p className="mb-2 text-xs font-semibold text-blue-400">
+										↓ Pulled ({syncResult.pulledMovies.length})
 									</p>
-									<p className="text-xs text-white/40">Errors</p>
+									<div className="flex flex-col gap-1">
+										{syncResult.pulledMovies.map((m) => (
+											<p key={m.id} className="text-xs text-white/70">
+												{m.title}
+											</p>
+										))}
+									</div>
 								</div>
-							)}
-						</div>
+							</>
+						)}
+						{syncResult.pushedMovies.length > 0 && (
+							<>
+								<div className="h-px bg-white/10" />
+								<div className="px-4 py-3">
+									<p className="mb-2 text-xs font-semibold text-green-400">
+										↑ Pushed ({syncResult.pushedMovies.length})
+									</p>
+									<div className="flex flex-col gap-1">
+										{syncResult.pushedMovies.map((m) => (
+											<p key={m.id} className="text-xs text-white/70">
+												{m.title}
+											</p>
+										))}
+									</div>
+								</div>
+							</>
+						)}
+						{syncResult.deletedMovies.length > 0 && (
+							<>
+								<div className="h-px bg-white/10" />
+								<div className="px-4 py-3">
+									<p className="mb-2 text-xs font-semibold text-red-400">
+										✕ Deleted ({syncResult.deletedMovies.length})
+									</p>
+									<div className="flex flex-col gap-1">
+										{syncResult.deletedMovies.map((m) => (
+											<p key={m.id} className="text-xs text-white/70">
+												{m.title}
+											</p>
+										))}
+									</div>
+								</div>
+							</>
+						)}
+						{syncResult.dedupedMovies.length > 0 && (
+							<>
+								<div className="h-px bg-white/10" />
+								<div className="px-4 py-3">
+									<p className="mb-2 text-xs font-semibold text-yellow-400">
+										~ Deduped ({syncResult.dedupedMovies.length})
+									</p>
+									<div className="flex flex-col gap-1">
+										{syncResult.dedupedMovies.map((m) => (
+											<p key={m.id} className="text-xs text-white/70">
+												{m.title}
+											</p>
+										))}
+									</div>
+								</div>
+							</>
+						)}
+						{!hasAnyResult && (
+							<>
+								<div className="h-px bg-white/10" />
+								<p className="px-4 py-3 text-xs text-white/40">
+									Already up to date
+								</p>
+							</>
+						)}
 						{syncResult.errors.length > 0 && (
 							<>
 								<div className="h-px bg-white/10" />
 								<div className="flex flex-col gap-1 px-4 py-3">
+									<p className="mb-1 text-xs font-semibold text-red-400">
+										Errors ({syncResult.errors.length})
+									</p>
 									{syncResult.errors.map((err) => (
-										<p key={err} className="text-xs text-red-400">
+										<p key={err} className="text-xs text-red-400/70">
 											{err}
 										</p>
 									))}


### PR DESCRIPTION
- MovieForm: replace separate TMDB search sheet with inline title autocomplete dropdown; physical/digital toggles moved next to poster
- Sync: SyncResult now tracks pushed/pulled/deleted/deduped movie lists; SyncView shows per-movie detail lists after each sync run; local dedup runs before push to prevent endless push loop on duplicate TMDB entries
- CollectionView: physical/digital filter chips gain a third 'hidden' state (red) that excludes matching movies — cycles null → on → hidden
- CLAUDE.md: fix git branch command reference